### PR TITLE
Add Git LFS instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,17 @@
 Acest repo conține codul din spatele site-ului de prezentare al hackathon-ului
 Smarthack, organizat de Asociația Studenților la Matematică și Informatică.
 
-Pentru a vedea site-ul live intrați pe [smarthack.as-mi.ro](http://smarthack.as-mi.ro/)
+Pentru a vedea site-ul live intrați pe [smarthack.asmi.ro](https://smarthack.asmi.ro/)
 
 # Instrucțiuni pentru developeri
 
 Cerințe:
 * Node >= 10
 * NPM
+* Repository-ul folosește [Git Large File Storage (LFS)](https://git-lfs.github.com/)
+  pentru a stoca imaginile și documentele binare.
+  * Pe Windows, vine de obicei instalat cu Git.
+  * Pe alte sisteme, poate fi instalat din package manager.
 
 ### Instalare dependințe
 ```{bash}
@@ -25,4 +29,3 @@ npm run dev
 ```{bash}
 npm run build
 ```
-


### PR DESCRIPTION
The project uses Git Large File Storage, but we didn't mention this in the README. Not having it installed can lead to problems with cloning the repo on Linux.